### PR TITLE
Adjust README for Kafka Raft and Ansible deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,178 +1,102 @@
-Remedios
-========
+# Remedios en Always Free (Oracle ARM 1C/6GB)
 
-Webhook de WhatsApp desplegado en Kubernetes (k3s) que encola los eventos en Kafka. Se sirve detrás de Traefik con TLS automático de Let’s Encrypt.
+Remedios es un webhook de WhatsApp escrito en Flask que publica los eventos en Kafka y se sirve detrás de Traefik con certificados emitidos automáticamente. Este README está pensado para desplegar el stack actual (y los servicios de la próxima release) en instancias **Always Free** de Oracle Cloud con 1 CPU ARM y 6 GB de RAM cada una.
 
-Contenido clave
----------------
-- **Aplicación**: Flask (`zordon/server.py`) con endpoints `/webhook` (POST/GET) y `/health`. Envía los mensajes a Kafka (`whatsapp-text` o `whatsapp-audio`) usando `BOOTSTRAP_SERVER`.
-- **Infra**: manifiestos y scripts en `zordon/`:
-  - `master-init.sh`: instala k3s, abre puertos, fija rutas CNI internas, aplica Traefik + ACME y despliega Kafka y la app sobre tailscale0.
-  - `node-init.sh`: añade workers a ese cluster k3s, también sobre tailscale0.
-  - `traefik-acme.yaml`: configura Traefik para certs Let’s Encrypt (HTTP-01).
-  - `remedios.yaml`: Deployment/Service/Ingress de la app.
-  - `kafka.yaml`: despliegue de Kafka/Zookeeper.
-  - `whatsapp-consumer.yaml`: consumidor (si lo necesitas).
+## Qué vas a desplegar
+- **Aplicación Remedios** (`zordon/server.py`): expone `/webhook` y `/health`, envía texto y audio a topics de Kafka.
+- **Kafka (modo Raft, sin Zookeeper)** en el namespace `kafka`.
+- **Traefik** con ACME HTTP-01 y TLS automático.
+- **Tailscale** para la red privada entre nodos (k3s usa `tailscale0`).
+- **Manifiestos y bootstrap** en `zordon/` (`remedios.yaml`, `kafka.yaml`, `traefik-acme.yaml`, scripts `master-init.sh` y `node-init.sh`).
+- **Playbooks Ansible** opcionales (`zordon/ansible/`) para automatizar el cluster y los servicios.
 
-Requisitos
-----------
-- Ubuntu 22.04+ con acceso root.
-- Dominio público apuntando al IP público de la instancia (A/CNAME para `${DOMAIN}` y, opcional, `www`). Puertos 80 y 443 abiertos.
-- `.secrets` en `zordon/` con:
-  - `DOMAIN=tu.dominio`
-  - `WEBHOOK_VERIFY_TOKEN=token_webhook` (opcional pero recomendado)
-  - `TAILSCALE_AUTHKEY=tskey-...` (auth key de Tailscale)
-  - Para workers: `MASTER_TAILSCALE_IP=100.x.y.z` (IP tailscale del master) y `K3S_TOKEN=<node-token>`; si usas MagicDNS, puedes poner `MASTER_TAILSCALE_HOST=host.tailnet.ts.net` y olvidarte de la IP.
-  - (opcional) `TAILSCALE_HOSTNAME=nombre-personalizado`, `TAILSCALE_MAGICDNS_HOST=host.tailnet.ts.net` para añadirlo como SAN en el API server, `TAILSCALE_UP_FLAGS="--ssh"` si reejecutas sobre una máquina que ya tenía `tailscale up` con SSH u otros flags.
-  - (añade otras vars si las necesitas)
+## Requisitos previos
+- Instancias Oracle Cloud **ARM** (mínimo 1 master, opcional workers), Ubuntu 22.04+ con sudo.
+- Puertos 80/443 abiertos en cada nodo para Traefik.
+- Un dominio público apuntando a la IP pública del master.
+- Cuenta de Tailscale con auth key (idealmente efímera y reusable).
+- (Opcional) Credenciales de GHCR si consumes imágenes privadas: `GHCR_USERNAME`, `GHCR_TOKEN`.
 
-Despliegue rápido en instancia nueva
-------------------------------------
-1) Clona el repo y ve a `zordon/`.
-2) Crea `.secrets` con las variables anteriores.
-3) Ejecuta el bootstrap:
+## Preparar las instancias
+1. Crea las VM Always Free (1C/6GB) y habilita el puerto 22 + 80/443 en las reglas de seguridad.
+2. En el **master**, instala dependencias básicas y clona el repo:
    ```bash
-   cd zordon
-   bash master-init.sh
+   sudo apt-get update && sudo apt-get install -y git jq curl
+   git clone https://github.com/borisfaj/remedios.git
+   cd remedios/zordon
    ```
-   El script:
-   - Instala k3s.
-   - Detecta (o usa `TAILSCALE_MAGICDNS_HOST`) y añade el MagicDNS del master como SAN TLS para que puedas usar el hostname en kubeconfig/join.
-   - Asegura rutas de red internas (10.42.0.0/16 pods, 10.43.0.0/16 servicios) por la interfaz CNI.
-   - Aplica Traefik con ACME (HTTP-01).
-   - Despliega Kafka (`kafka` namespace).
-   - Despliega Remedios (`remedios` namespace) renderizando `remedios.yaml` con `envsubst`.
+3. Crea el fichero `.secrets` en `zordon/` con las variables mínimas:
+   ```bash
+   cat <<'EOFVARS' > .secrets
+   DOMAIN=tu.dominio
+   WEBHOOK_VERIFY_TOKEN=token_webhook
+   TAILSCALE_AUTHKEY=tskey-...
+   # Opcionales
+   TAILSCALE_HOSTNAME=remedios-master
+   GHCR_USERNAME=...
+   GHCR_TOKEN=...
+   EOFVARS
+   ```
 
-Workers sobre Tailscale
------------------------
-- Ejecuta `bash master-init.sh` primero. Guarda el `K3S_TOKEN` desde `/var/lib/rancher/k3s/server/node-token` y la IP de tailscale (`tailscale ip -4 | head -n1`) o su MagicDNS (`tailscale status --json | jq -r '.Self.DNSName'`).
-- En cada worker copia `.secrets` con `TAILSCALE_AUTHKEY`, `K3S_TOKEN` y **una** de estas dos: `MASTER_TAILSCALE_IP` (100.x) o `MASTER_TAILSCALE_HOST` (MagicDNS tipo `host.tailnet.ts.net`). Opcionalmente `TAILSCALE_HOSTNAME`. Luego ejecuta `bash node-init.sh`.
-- Todo el tráfico de control y flannel viaja por `tailscale0`; expone 80/443 hacia Internet para Traefik como antes.
+## Añadir workers (opcional)
+1. Copia `.secrets` al worker y añade:
+   ```bash
+   MASTER_TAILSCALE_IP=100.x.y.z    # o MASTER_TAILSCALE_HOST=host.tailnet.ts.net
+   K3S_TOKEN=$(ssh master sudo cat /var/lib/rancher/k3s/server/node-token)
+   ```
+2. Ejecuta en cada worker:
+   ```bash
+   cd ~/remedios/zordon
+   bash node-init.sh
+   ```
+3. Valida que aparece como `Ready` con IP 100.x en:
+   ```bash
+   sudo k3s kubectl get nodes -o wide
+   ```
 
-Despliegue con Ansible (Tailscale automático)
----------------------------------------------
-- Prepara un inventario con grupos `master` y `nodes` (ejemplo en `zordon/ansible/inventory.example.ini`).
-- Crea en tu máquina (no se trackea en git) el fichero `zordon/.secrets` con las variables base (`DOMAIN`, `WEBHOOK_VERIFY_TOKEN`, `TAILSCALE_AUTHKEY`, opcional `TAILSCALE_HOSTNAME`). No pongas `MASTER_TAILSCALE_IP`/`MASTER_TAILSCALE_HOST` ni `K3S_TOKEN`; el playbook los añadirá en destino.
-- Si usas imágenes privadas en GHCR, añade en `.secrets`: `GHCR_USERNAME` (tu usuario de GitHub) y `GHCR_TOKEN` (PAT con `read:packages`). El script creará el secret `ghcr-creds` en el namespace `remedios` y los deployments ya lo referencian en `imagePullSecrets`.
-- Ejecuta desde la raíz del repo:
+## Despliegue con Ansible
+La vía soportada es Ansible (sin bootstrap manual):
+1. Ajusta `zordon/ansible/inventory.example.ini` y guarda tu inventario como `inventory.ini`.
+2. Prepara `zordon/.secrets` en tu máquina local con las mismas variables base del master (sin `MASTER_TAILSCALE_IP/HOST` ni `K3S_TOKEN`).
+3. Despliega el **cluster y el core** (k3s + Traefik + Kafka Raft + Remedios) con:
+   ```bash
+   ansible-playbook -i zordon/ansible/inventory.ini zordon/ansible/cluster.yml
+   ```
+4. Cuando el cluster ya existe, despliega los **servicios** adicionales (release en curso) con:
+   ```bash
+   ansible-playbook -i zordon/ansible/inventory.ini zordon/ansible/services.yml --limit master
+   ```
+
+## Verificación rápida
+- Listar recursos clave:
   ```bash
-  ansible-playbook -i zordon/ansible/inventory.ini zordon/ansible/cluster.yml
-  ```
-- El playbook copia los scripts, bootstrappea el master, obtiene automáticamente la IP/MagicDNS de tailscale y el `K3S_TOKEN`, y luego une los workers sin que tengas que pasar manualmente esos datos.
-- Playbook opcional para servicios: cuando el cluster ya está arriba, puedes construir y desplegar `remetext` con imagen local (sin tirar de registry) usando `zordon/ansible/services.yml`. Requisitos: kubeconfig en `/etc/rancher/k3s/k3s.yaml` en el master y `nerdctl` disponible. Ejemplo:
-  ```bash
-  ansible-playbook -i zordon/ansible/inventory.ini zordon/ansible/services.yml --limit master
-  ```
-  El playbook sincroniza `remedios/`, **asume que la imagen multi-arch ya está publicada** en `ghcr.io/borisfaj/remetext:latest` (se construye en CI), crea los Secrets (`remedios-secrets` con tus vars de `.secrets` y `ghcr-creds` si defines `GHCR_USERNAME`/`GHCR_TOKEN` para pulls privados), aplica `zordon/remetext.yaml` y fuerza un rollout del deployment `remetext` en el namespace `remedios`.
-- Casos de uso:
-  - **Cluster de un solo nodo (solo master)**: define solo el host en `master` (o usa `--limit master`). No es necesario declarar `nodes`.
-  - **Cluster nuevo con varios nodos**: define `master` + `nodes` y ejecuta el playbook completo (sin `--limit`).
-  - **Añadir workers a un cluster existente**: añade los nuevos hosts en el grupo `nodes` y ejecuta `ansible-playbook ... --limit <host1>,<host2>` (o `--limit nodes` si solo hay nuevos). El play contactará al `master` del inventario para leer su IP de tailscale (y su MagicDNS si existe) y el token, sin reprovisionar el master.
-  - **Solo añadir un worker concreto**: deja el `master` definido en el inventario (para poder delegar), añade el host al grupo `nodes` y ejecuta, por ejemplo:
-    ```bash
-    ansible-playbook -i zordon/ansible/inventory.ini zordon/ansible/cluster.yml --limit master1,worker2
-    ```
-    Incluir el master en el `--limit` permite delegar la lectura de IP/token sin tocarlo; no se reprovisiona.
-
-Token de GitHub para GHCR
--------------------------
-- Ve a GitHub → Settings → Developer settings → Personal access tokens.
-- Crea un token (clásico o fine-grained) con permiso `read:packages`.
-- Usa tu usuario de GitHub como `GHCR_USERNAME` y ese token como `GHCR_TOKEN` en `.secrets`.
-
-Notas sobre whatsapp-consumer
------------------------------
-- El manifiesto `whatsapp-consumer.yaml` solo despliega el consumer (no incluye los servicios `remetext/whisper-turbo`). Ajusta en el ConfigMap `whatsapp-consumer-config` los endpoints `TEXT_ENDPOINT` y `AUDIO_ENDPOINT` a tus servicios reales antes de aplicarlo.
-
-Cómo obtener el auth key de Tailscale
--------------------------------------
-- Entra a https://login.tailscale.com → Settings → Keys → Generate auth key (idealmente *ephemeral* + reusable si quieres añadir nodos).
-- Usa ese valor como `TAILSCALE_AUTHKEY` en `group_vars/all.yml` o en tus variables de inventario.
-
-Verificación
-------------
-- Traefik/ACME:
-  ```bash
-  sudo k3s kubectl -n kube-system logs -l app.kubernetes.io/name=traefik -f
-  ```
-  Debes ver el challenge y la emisión para tu dominio; el Secret `remedios-tls` aparecerá en el ns `remedios`.
-
-- Certificado:
-  ```bash
-  sudo k3s kubectl -n remedios get secret remedios-tls -o jsonpath='{.data.tls\.crt}' \
-    | base64 -d | openssl x509 -noout -issuer -subject -dates
-  ```
-
-- Salud HTTP/HTTPS:
-  ```bash
-  curl -v https://$DOMAIN/health
-  curl -v "https://$DOMAIN/webhook?hub.mode=subscribe&hub.verify_token=$WEBHOOK_VERIFY_TOKEN&hub.challenge=123"
-  ```
-
-- DNS/Challenge:
-  ```bash
-  curl -v http://$DOMAIN/.well-known/acme-challenge/test
-  ```
-  Debe responder 404 desde Traefik sin redirecciones.
-
-- Cluster sobre Tailscale/MagicDNS:
-  ```bash
-  sudo k3s kubectl get nodes -o wide                  # InternalIP 100.x y Ready
-  sudo k3s kubectl get pods -A -o wide                # kube-system/flannel/traefik en Running
-  sudo k3s kubectl cluster-info
-  grep server: /etc/rancher/k3s/k3s.yaml              # Debe apuntar a tu MagicDNS:6443
-  sudo k3s kubectl -n remedios get all                # Recursos de la app
-  sudo k3s kubectl -n kafka get all                   # Kafka
-  sudo k3s kubectl -n remedios exec deploy/whatsapp-consumer -- printenv BOOTSTRAP_SERVER
-  sudo k3s kubectl -n remedios logs deploy/remedios | tail
-  curl -v https://$DOMAIN/health
-  ```
-
-Despliegue manual (si ya tienes k3s)
-------------------------------------
-```bash
-cd zordon
-set -a; . .secrets; set +a
-kubectl apply -n kube-system -f traefik-acme.yaml
-envsubst '$DOMAIN $WEBHOOK_VERIFY_TOKEN' < remedios.yaml | kubectl apply -n remedios -f -
-```
-
-Notas sobre red
----------------
-- Traefik necesita llegar al API de k8s (`10.43.0.1:443`). Si ves en sus logs `no route to host`, asegúrate de que el host tiene rutas a 10.42.0.0/16 y 10.43.0.0/16 por la interfaz CNI (`cni0`/`flannel.1`). El `cloud-init.sh` ya las instala; en sistemas existentes:
-  ```bash
-  sudo ip route replace 10.43.0.0/16 dev cni0
-  sudo ip route replace 10.42.0.0/16 dev cni0
-  ```
-
-Kafka
------
-- Kafka se despliega en el namespace `kafka` con `kafka.yaml`.
-- El productor Flask usa `BOOTSTRAP_SERVER` del ConfigMap (`kafka.kafka.svc.cluster.local:9092` por defecto).
-- Topics usados: `whatsapp-text`, `whatsapp-audio`.
-
-Referencias rápidas
--------------------
-- Listar recursos:
-  ```bash
-  kubectl -n remedios get all
-  kubectl -n kafka get all
+  sudo k3s kubectl -n remedios get all
+  sudo k3s kubectl -n kafka get all
   ```
 - Logs de la app:
   ```bash
-  kubectl -n remedios logs deploy/remedios -f
+  sudo k3s kubectl -n remedios logs deploy/remedios -f
   ```
-- Consumidor de ejemplo (desde el pod de Kafka):
+- Consumidor de ejemplo desde Kafka:
   ```bash
-  kubectl -n kafka exec -it deploy/kafka -- \
+  sudo k3s kubectl -n kafka exec -it deploy/kafka -- \
     kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic whatsapp-text --from-beginning
   ```
 
-Próximos pasos
---------------
-- Añadir/activar los pipelines de Whisper/GPT (consumidor en `whatsapp_consumer.py` y manifiesto `whatsapp-consumer.yaml`).
-- Documentar credenciales externas necesarias (si aplica).
+## Servicios de la próxima release
+Los manifiestos siguen el mismo patrón (Traefik + Secrets + imagePullSecrets). Cuando publiques nuevas imágenes multi-arch, agrégalas a los YAML de `zordon/` y reutiliza los Secrets existentes.
 
-Licencia
---------
-MIT. Veja `LICENSE`.
+<details>
+<summary>Notas y issues a tener en cuenta</summary>
+
+- Tailscale debe estar arriba antes de unir workers; usa `tailscale status --json | jq -r '.Self.DNSName'` para MagicDNS.
+- Traefik necesita rutas a `10.42.0.0/16` y `10.43.0.0/16` por la interfaz CNI (`cni0`/`flannel.1`).
+- Certificados ACME: valida que el challenge HTTP-01 responde en 80; el Secret `remedios-tls` aparece en el ns `remedios`.
+- Si usas GHCR privado, define `GHCR_USERNAME/GHCR_TOKEN` para crear el secret `ghcr-creds` y referenciarlo en `imagePullSecrets`.
+- El webhook opcionalmente valida `WEBHOOK_VERIFY_TOKEN` en la suscripción de WhatsApp.
+- Las instancias Always Free no tienen almacenamiento persistente abundante; monitoriza el disco de Kafka o usa temas compactados.
+
+</details>
+
+## Licencia
+MIT, ver `LICENSE`.


### PR DESCRIPTION
## Summary
- correct the architecture description to reference Kafka in Raft mode without Zookeeper
- remove the manual bootstrap section and document Ansible as the supported path for cluster/core and services

## Testing
- not run (documentation-only change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939b05582a083219a58207e25367b64)